### PR TITLE
Handle user role fetch error

### DIFF
--- a/app/flashcards/page.tsx
+++ b/app/flashcards/page.tsx
@@ -374,10 +374,11 @@ export default function FlashcardsPage() {
         const { data: { user } } = await supabase.auth.getUser();
         if (user?.id) {
           const role = await getUserRoleClient(user.id)
-          setUserRole(role)
+          setUserRole(role || 'student') // Garante que sempre teremos um valor
         }
       } catch (error) {
-        console.error("Erro ao verificar role:", error)
+        console.log("Erro ao verificar role do usuário:", error instanceof Error ? error.message : 'Erro desconhecido')
+        setUserRole('student') // Define 'student' como padrão em caso de erro
       }
     }
     checkUserRole()

--- a/lib/get-user-role.ts
+++ b/lib/get-user-role.ts
@@ -13,19 +13,29 @@ export async function getUserRoleClient(userId: string) {
       .single();
 
     if (error) {
-      console.error('Erro ao buscar role:', error);
+      // Log mais detalhado do erro
+      console.log('Erro ao buscar role:', {
+        code: error.code,
+        message: error.message,
+        details: error.details,
+        hint: error.hint
+      });
+      
       // Se não encontrar role, retorna 'student' como padrão
       if (error.code === 'PGRST116') {
         console.log('Nenhum role encontrado, retornando student como padrão');
         return 'student';
       }
-      return null;
+      
+      // Para outros erros, também retorna 'student' como padrão
+      console.log('Erro inesperado ao buscar role, retornando student como padrão');
+      return 'student';
     }
 
     console.log('Role encontrado:', data?.role);
     return data?.role || 'student';
   } catch (err) {
-    console.error('Erro na função getUserRoleClient:', err);
+    console.log('Erro na função getUserRoleClient:', err instanceof Error ? err.message : String(err));
     return 'student';
   }
 }


### PR DESCRIPTION
Improve user role fetching error handling to prevent console errors and ensure a default role.

The previous implementation would log an empty object as an error and could return `null` if the user's role was not found or an RLS issue occurred, leading to unhandled client-side errors. This change ensures a 'student' role is always provided as a fallback and errors are logged more gracefully.

---

[Open in Web](https://cursor.com/agents?id=bc-0bc784cc-8ded-4c41-9922-97bb8fbf9ec4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0bc784cc-8ded-4c41-9922-97bb8fbf9ec4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)